### PR TITLE
Fix deserialize from binary buffer

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -21,11 +21,15 @@ export function serializeToBinary(value, type) {
 
 /**
  * Deserializes binary back to JavaScript value.
- * @param {DataView} view - buffer to deserialize.
+ * @param {DataView | ArrayBuffer | ArrayBufferLike} viewOrBuffer - buffer or dataView to deserialize.
  * @param {BaseTypeHandler} type - type handler of the desired value.
  * @returns {any} - the deserialized JavaScript value.
  */
-export function deserializeFromBinary(view, type) {
+export function deserializeFromBinary(viewOrBuffer, type) {
+	if (!(viewOrBuffer instanceof DataView)) { // Check if not a DataView instance already
+		if (ArrayBuffer.isView(viewOrBuffer)) viewOrBuffer = viewOrBuffer.buffer // It ifs not ArrayBuffer, take the ArrayBuffer inside it
+		viewOrBuffer = new DataView(viewOrBuffer) // Initialize a DataView
+	}
 	if (!(type instanceof BaseTypeHandler)) {
 		type = new CompoundTypeHandler(type);
 	}

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -34,6 +34,6 @@ export function deserializeFromBinary(viewOrBuffer, type) {
 		type = new CompoundTypeHandler(type);
 	}
 
-	const tmp = type.deserialize(view, 0);
+	const tmp = type.deserialize(viewOrBuffer, 0);
 	return tmp.value;
 }

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -27,7 +27,7 @@ export function serializeToBinary(value, type) {
  */
 export function deserializeFromBinary(viewOrBuffer, type) {
 	if (!(viewOrBuffer instanceof DataView)) { // Check if not a DataView instance already
-		if (ArrayBuffer.isView(viewOrBuffer)) viewOrBuffer = viewOrBuffer.buffer // It ifs not ArrayBuffer, take the ArrayBuffer inside it
+		if (ArrayBuffer.isView(viewOrBuffer)) viewOrBuffer = viewOrBuffer.buffer // If its not ArrayBuffer, take the ArrayBuffer inside it
 		viewOrBuffer = new DataView(viewOrBuffer) // Initialize a DataView
 	}
 	if (!(type instanceof BaseTypeHandler)) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -130,21 +130,21 @@ describe('binary-struct', () => {
 	describe('deserializeFromBinary', () => {
 		it('type i8', () => {
 			let binary_data = new Uint8Array([0x85]).buffer;
-			let res = deserializeFromBinary(new DataView(binary_data), BASIC_TYPES.i8);
+			let res = deserializeFromBinary(binary_data, BASIC_TYPES.i8);
 			let ans = -123;
 			assert.equal(res, ans);
 		});
 
 		it('type i16', () => {
 			let binary_data = new Uint8Array([0xc7, 0xcf]).buffer;
-			let res = deserializeFromBinary(new DataView(binary_data), BASIC_TYPES.i16);
+			let res = deserializeFromBinary(binary_data, BASIC_TYPES.i16);
 			let ans = -12345;
 			assert.equal(res, ans);
 		});
 
 		it('type i32', () => {
 			let binary_data = new Uint8Array([0x2e, 0xfd, 0x69, 0xb6]).buffer;
-			let res = deserializeFromBinary(new DataView(binary_data), BASIC_TYPES.i32);
+			let res = deserializeFromBinary(new Uint8Array(binary_data), BASIC_TYPES.i32);
 			let ans = -1234567890;
 			assert.equal(res, ans);
 		});


### PR DESCRIPTION
I made the deserializeFromBinary method understand ArrayBuffer, ArrayBufferLike and DataView.
This fixes the wrong example in the Readme.